### PR TITLE
Some fixes for language checks and additions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install highlight.js-cli -g
 
 ## Usage
 
-Input it taken from stdin, the default selector is "pre code", i.e. `<pre><code>...</code></pre>`. Other DOM elements than those fitting the selector are not highlighted.
+Input it taken from stdin and output to stdout if not specified otherwise (see example below). The default selector is "pre code", i.e. `<pre><code>...</code></pre>`. Other DOM elements than those fitting the selector are not highlighted.
 
 To highlight a file:
 
@@ -19,11 +19,19 @@ To highlight a file:
 hljs < input.html > output.html
 ```
 
-To highlight a string:
+You can also use the `--o` parameter:
+
+```
+hljs --o output.html < input.html
+```
+
+To highlight a multi-line string from stdin:
 
 ```
 hljs <<EOF
-<pre><code>var stuff="asd"</code></pre>
+<pre><code>
+var stuff="asd"
+</code></pre>
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
 highlight.js-cli
 ================
 
-Use [highlight.js](http://highlightjs.org/) from command line on HTML or Markdown files.
+Use [highlight.js](http://highlightjs.org/) from command line on HTML file.
 
-## Install
+## Installation
 
 ```
 npm install highlight.js-cli -g
 ```
 
-## Use
+## Usage
 
-Default selector is "pre code".
+Input it taken from stdin, the default selector is "pre code", i.e. `<pre><code>...</code></pre>`. Other DOM elements than those fitting the selector are not highlighted.
+
+To highlight a file:
 
 ```
 hljs < input.html > output.html
 ```
 
-To use a different selector use --s option. You can use any valid jQuery selector, for example:
+To highlight a string:
+
+```
+hljs <<EOF
+<pre><code>var stuff="asd"</code></pre>
+EOF
+```
+
+To use a different selector use `--s` option. You can use any valid jQuery selector, for example:
 
 ```
 hljs --s=".highlight" < input.html > output.html

--- a/bin/hljs
+++ b/bin/hljs
@@ -5,21 +5,27 @@ var cli = require('cli'),
 	cheerio = require('cheerio'),
 	Entities = require('html-entities').AllHtmlEntities,
 	entities = new Entities(),
-	opts = cli.parse();
-	
-var options = {
-    selector: 'pre code'
-};
-
-if (opts.s) {
-	options.selector = opts.s;
-}
+	opts = cli.parse({
+		selector: [
+			's', 
+			'jQuery style selector which specifies on which elements highlighting is applied', 
+			'string', 
+			'pre code'
+		]
+	});
 	
 cli.withStdin(function(input) {
 	var $ = cheerio.load(input);
-	$(options.selector).each(function(i, elem) {
+	var avaiableLanguages = hljs.listLanguages();
+	$(opts.selector).each(function(i, elem) {
 		var lang = $(this).attr('class');
-		$(this).text(lang ? hljs.highlight(lang, $(this).text()).value : hljs.highlightAuto($(this).text()).value).addClass('hljs');
+		var highlighted;
+		if(lang && avaiableLanguages.indexOf(lang.toLower) != -1){
+			highlighted = hljs.highlight(lang, $(this).text()).value;
+		} else {
+			highlighted = hljs.highlightAuto($(this).text()).value;
+		}
+		$(this).text(highlighted).addClass('hljs');
 	});
 	this.output(entities.decode($.html()));
 });

--- a/bin/hljs
+++ b/bin/hljs
@@ -6,12 +6,19 @@ var cli = require('cli'),
 	cheerio = require('cheerio'),
 	Entities = require('html-entities').AllHtmlEntities,
 	entities = new Entities(),
+	fs = require('fs'),
 	opts = cli.parse({
 		selector: [
 			's', 
 			'jQuery style selector which specifies on which elements highlighting is applied', 
 			'string', 
 			'pre code'
+		],
+		output: [
+			'o',
+			'Output file path',
+			'file',
+			false
 		]
 	});
 	
@@ -27,5 +34,10 @@ cli.withStdin(function(input) {
 		}
 		$(this).text(highlighted).addClass('hljs');
 	});
-	this.output(entities.decode($.html()));
+	var out = entities.decode($.html());
+	if(opts.output){
+		fs.writeFileSync(opts.output, out);
+	} else {
+		this.output(out);
+	}
 });

--- a/bin/hljs
+++ b/bin/hljs
@@ -2,6 +2,7 @@
 
 var cli = require('cli'),
 	hljs = require('highlight.js'),
+	avaiableLanguages = hljs.listLanguages(),
 	cheerio = require('cheerio'),
 	Entities = require('html-entities').AllHtmlEntities,
 	entities = new Entities(),
@@ -16,7 +17,6 @@ var cli = require('cli'),
 	
 cli.withStdin(function(input) {
 	var $ = cheerio.load(input);
-	var avaiableLanguages = hljs.listLanguages();
 	$(opts.selector).each(function(i, elem) {
 		var lang = $(this).attr('class');
 		var highlighted;

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     }
   ],
   "dependencies": {
-    "highlight.js": "*",
-    "cheerio": "*",
-	"cli": "*",
-	"html-entities": "*"
+    "highlight.js": "~8.7",
+    "cheerio": "~0.19",
+	  "cli": "~0.9",
+	  "html-entities": "~1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "highlight.js": "~8.7",
     "cheerio": "~0.19",
-	  "cli": "~0.9",
-	  "html-entities": "~1.1"
+    "cli": "~0.9",
+    "html-entities": "~1.1"
   }
 }


### PR DESCRIPTION
There was an error if a language was specified via e.g. `class="lang-JSON"`, but unsupported by highlight.js (in this case because JSON was written in capital letters, npm module "marked" produces code like this). I added a check that will prevent this by lower-casing the attribute and then checking against highlight.js' `listLanguages()`.

I added some more explanation and examples to the Readme.

I also specified version numbers for dependencies, in case a dependency updates and breaks this package.

Furthermore, the `--o / output` parameter allows you to write into the same input as output file.
